### PR TITLE
Add TradeCast trade sharing experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# TradeCast-V1
-A tradecasting system on Farcaster
+# TradeCast V1
+
+TradeCast turns onchain trades into Farcaster-native content. The project demonstrates how a Base builder can compose data from
+open APIs, bundle it inside a cast-ready UI, and ship mirror buttons that let anyone copy the move in seconds.
+
+## Features
+
+- **Live Trade Feed** – Query DexScreener and GeckoTerminal to surface real Base trades with tx hashes, trader addresses, and
+  price snapshots.
+- **Mirror Buttons** – Auto-generate swap links (Uniswap, Aerodrome, custom) so followers can mirror the trade instantly.
+- **Cast Composer** – Draft TradeCast payloads with proof links and wallet metadata ready for Warpcast, Frames, or Monad mini
+  apps.
+- **Future Roadmap** – Highlights how to extend the concept with follow systems, leaderboards, and onchain receipts.
+
+## Running locally
+
+```bash
+npm install
+npm run dev
+```
+
+The app runs at `http://localhost:3000`. Fetching live trade data requires outbound network access because it hits open APIs
+( DexScreener and GeckoTerminal ).
+
+## API
+
+`GET /api/tradecasts?token=<query>`
+
+Returns TradeCast objects that include trade metadata, BaseScan proof links, mirror URLs, and optional chart points.
+
+## Deployment
+
+The project is optimized for Vercel (zero-config). Environment variables are not required by default, but you can optionally
+proxy API calls through your own edge function if rate limits are encountered.

--- a/app/api/tradecasts/route.ts
+++ b/app/api/tradecasts/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { fetchChartPoints, fetchRecentTrades, searchPairsByToken, toTradeCast } from "@/lib/dexscreener";
+import type { TradeCast } from "@/lib/types";
+
+export const revalidate = 15;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const token = searchParams.get("token");
+  const limit = Number(searchParams.get("limit") ?? "8");
+
+  if (!token) {
+    return NextResponse.json({ error: "Missing token parameter" }, { status: 400 });
+  }
+
+  try {
+    const pairs = await searchPairsByToken(token.toLowerCase());
+    const selectedPairs = pairs.slice(0, Math.max(1, Math.min(limit, 4)));
+
+    const casts: TradeCast[] = [];
+
+    for (const pair of selectedPairs) {
+      const [trades, chart] = await Promise.all([
+        fetchRecentTrades(pair, 4),
+        fetchChartPoints(pair, 16),
+      ]);
+
+      trades.forEach((trade) => {
+        casts.push(toTradeCast(pair, trade, chart));
+      });
+    }
+
+    return NextResponse.json({ casts });
+  } catch (error) {
+    console.error("failed to load tradecasts", error);
+    return NextResponse.json({ error: "Failed to load tradecasts" }, { status: 500 });
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,23 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-surface text-white;
+}
+
+.gradient-border {
+  position: relative;
+  border-radius: 1.25rem;
+  background: linear-gradient(135deg, rgba(93, 107, 255, 0.7), rgba(246, 193, 119, 0.6));
+  padding: 1px;
+}
+
+.gradient-border > .gradient-content {
+  border-radius: 1.2rem;
+  background: rgba(9, 12, 23, 0.85);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { Inter } from "next/font/google";
+import { ReactNode } from "react";
+import { Providers } from "./providers";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
+
+export const metadata: Metadata = {
+  title: "TradeCast by Base",
+  description:
+    "Turn onchain trades into viral Farcaster casts complete with proofs, mirroring, and price context.",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" className="bg-surface text-white">
+      <body
+        className={`${inter.variable} font-sans min-h-screen bg-gradient-to-b from-surface via-surface to-black`}
+      >
+        <Providers>
+          <div className="mx-auto flex min-h-screen max-w-6xl flex-col px-4 pb-16 pt-10 sm:px-6 lg:px-8">
+            {children}
+          </div>
+        </Providers>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,126 @@
+import { TradeFeed } from "@/components/trade-feed";
+import { TradeComposer } from "@/components/trade-form";
+import { Sparkles, Zap, Share2, Activity } from "lucide-react";
+
+const highlights = [
+  {
+    icon: Sparkles,
+    title: "Cast from any Base wallet",
+    body: "Point TradeCast at a wallet or token and auto-generate a Farcaster-ready post with receipts.",
+  },
+  {
+    icon: Share2,
+    title: "Mirror-ready buttons",
+    body: "Attach Uniswap, Aerodrome, or custom links so friends can copy the move instantly.",
+  },
+  {
+    icon: Activity,
+    title: "Onchain proof baked in",
+    body: "Every cast bundles the tx hash, BaseScan link, and price snapshot so followers trust the trade.",
+  },
+  {
+    icon: Zap,
+    title: "Mini app & Frame compatible",
+    body: "Drop TradeCast inside Warpcast Frames or Monad mini apps without touching heavy infra.",
+  },
+];
+
+export default function Page() {
+  return (
+    <main className="flex flex-1 flex-col gap-12">
+      <section className="space-y-8">
+        <div className="rounded-3xl border border-white/20 bg-gradient-to-br from-primary/20 via-surface/80 to-black/80 p-10 shadow-2xl shadow-primary/30">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+            <div className="max-w-3xl space-y-4">
+              <span className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/20 px-4 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-primary-foreground">
+                Base builder drop
+              </span>
+              <h1 className="text-4xl font-semibold sm:text-5xl">TradeCast: turn your onchain flex into social fire</h1>
+              <p className="text-lg text-white/80">
+                TradeCast is a Farcaster-native feed that converts Base trades into shareable casts. Pull live swaps, mirror
+                the move in one tap, and stack Base Builder XP without shipping heavy contracts.
+              </p>
+              <div className="flex flex-wrap gap-3 text-sm">
+                <a
+                  className="rounded-full bg-primary px-6 py-2 font-semibold text-primary-foreground shadow-lg shadow-primary/50 transition hover:shadow-glow"
+                  href="https://warpcast.com/~/compose?text=Posting%20my%20first%20TradeCast%20from%20Base"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Launch on Warpcast
+                </a>
+                <a
+                  className="rounded-full border border-white/20 px-6 py-2 font-semibold text-white/80 transition hover:border-white/50"
+                  href="https://docs.base.org"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Builder docs
+                </a>
+              </div>
+            </div>
+            <div className="rounded-3xl border border-white/10 bg-black/40 p-6 text-sm text-white/70 lg:max-w-sm">
+              <h2 className="text-lg font-semibold text-white">How it works</h2>
+              <ol className="mt-4 space-y-3">
+                <li>
+                  <strong className="text-white">1. Fetch</strong> — Point at Base trades with open APIs like DexScreener or GeckoTerminal.
+                </li>
+                <li>
+                  <strong className="text-white">2. Cast</strong> — Wrap the trade in Farcaster-ready metadata: proof, chart, wallet.
+                </li>
+                <li>
+                  <strong className="text-white">3. Mirror</strong> — Offer quick mirror links so followers can execute in one tap.
+                </li>
+              </ol>
+              <p className="mt-4 text-xs uppercase tracking-wide text-white/40">
+                Deploys free on Vercel • Optional contract to notarize trades • Wallet connect ready via Wagmi
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {highlights.map((highlight) => (
+            <article key={highlight.title} className="rounded-3xl border border-white/10 bg-white/5 p-5 text-sm text-white/70">
+              <highlight.icon className="mb-3 h-6 w-6 text-primary" />
+              <h3 className="text-base font-semibold text-white">{highlight.title}</h3>
+              <p className="mt-2 text-sm text-white/70">{highlight.body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-10 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <TradeFeed />
+        <TradeComposer />
+      </section>
+
+      <section className="rounded-3xl border border-white/10 bg-black/40 p-10">
+        <h2 className="text-2xl font-semibold">Where TradeCast can go next</h2>
+        <div className="mt-6 grid gap-6 lg:grid-cols-3">
+          <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/70">
+            <h3 className="text-lg font-semibold text-white">Mirrors & follows</h3>
+            <p className="mt-2 text-sm">
+              Ship a follow contract that auto-executes swaps whenever a wallet you subscribe to casts. Add allowlists or spend
+              caps so users can mirror without fear.
+            </p>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/70">
+            <h3 className="text-lg font-semibold text-white">Leaderboards</h3>
+            <p className="mt-2 text-sm">
+              Score traders on realized PnL or win-rate, then plug rankings into Warpcast channels. Reward top wallets with Base
+              Builder XP or sponsor drops.
+            </p>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/70">
+            <h3 className="text-lg font-semibold text-white">Smart contract receipts</h3>
+            <p className="mt-2 text-sm">
+              Deploy a lightweight Base contract that notarizes trade payloads. Casts link to the contract log so the social
+              proof survives even if an API disappears.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode, useState } from "react";
+
+export function Providers({ children }: { children: ReactNode }) {
+  const [client] = useState(() => new QueryClient());
+
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/components/trade-cast-card.tsx
+++ b/components/trade-cast-card.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { TradeCast } from "@/lib/types";
+import { formatRelativeTime, formatTokenAmount, formatUsd, shortenAddress, shortenHash } from "@/lib/format";
+import { Area, AreaChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { useMemo } from "react";
+
+interface TradeCastCardProps {
+  cast: TradeCast;
+}
+
+export function TradeCastCard({ cast }: TradeCastCardProps) {
+  const { pair, trade, proofUrl, mirrorUrl, chart } = cast;
+
+  const chartData = useMemo(
+    () =>
+      chart?.map((point) => ({
+        time: new Date(point.time).toLocaleTimeString(undefined, {
+          hour: "2-digit",
+          minute: "2-digit",
+        }),
+        price: point.priceUsd,
+      })) ?? [],
+    [chart],
+  );
+
+  return (
+    <Card className="gradient-border">
+      <div className="gradient-content">
+        <CardHeader className="space-y-3 border-b border-white/5 bg-white/5 px-6 py-5">
+          <div className="flex items-center justify-between gap-4">
+            <CardTitle className="text-lg font-semibold text-white">
+              {trade.direction === "buy" ? "Bought" : "Sold"} {formatTokenAmount(trade.amountToken)} {pair.tokenSymbol}
+            </CardTitle>
+            <span className="rounded-full bg-primary/30 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary-foreground">
+              {pair.network}
+            </span>
+          </div>
+          <p className="text-sm text-white/70">
+            {formatUsd(trade.amountUsd)} @ {formatUsd(trade.priceUsd)} • {formatRelativeTime(trade.timestamp)} by {shortenAddress(trade.trader)}
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-6 px-6 py-5">
+          {chartData.length > 0 ? (
+            <div className="h-40 w-full overflow-hidden rounded-xl border border-white/5 bg-black/20">
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={chartData} margin={{ top: 12, right: 16, left: 0, bottom: 12 }}>
+                  <defs>
+                    <linearGradient id={`priceGradient-${cast.id}`} x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="#5D6BFF" stopOpacity={0.9} />
+                      <stop offset="95%" stopColor="#5D6BFF" stopOpacity={0.05} />
+                    </linearGradient>
+                  </defs>
+                  <XAxis dataKey="time" stroke="#666" fontSize={12} tickLine={false} axisLine={false} interval="preserveEnd" />
+                  <YAxis hide domain={["auto", "auto"]} />
+                  <Tooltip
+                    cursor={{ stroke: "#5D6BFF", strokeDasharray: "4 4" }}
+                    contentStyle={{
+                      background: "#0b0e1a",
+                      borderRadius: "0.75rem",
+                      border: "1px solid rgba(255,255,255,0.1)",
+                      color: "white",
+                    }}
+                    formatter={(value) => [formatUsd(Number(value)), "Price"]}
+                  />
+                  <Area type="monotone" dataKey="price" stroke="#5D6BFF" strokeWidth={2} fillOpacity={1} fill={`url(#priceGradient-${cast.id})`} />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            <p className="text-sm text-white/60">
+              Waiting for price snapshot… charts load once GeckoTerminal provides OHLCV data.
+            </p>
+          )}
+
+          <div className="flex flex-wrap items-center gap-3 text-sm text-white/70">
+            <a
+              className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 transition hover:border-primary/70 hover:bg-primary/20"
+              href={proofUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Onchain proof {shortenHash(trade.txHash)}
+            </a>
+            {mirrorUrl ? (
+              <a
+                className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-1 text-sm font-semibold text-primary-foreground transition hover:shadow-glow"
+                href={mirrorUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Mirror trade
+              </a>
+            ) : null}
+            {pair.dexUrl ? (
+              <a
+                className="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 transition hover:border-white/40"
+                href={pair.dexUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                View pair
+              </a>
+            ) : null}
+          </div>
+        </CardContent>
+      </div>
+    </Card>
+  );
+}

--- a/components/trade-feed.tsx
+++ b/components/trade-feed.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { TradeCast } from "@/lib/types";
+import { TradeCastCard } from "./trade-cast-card";
+import { RefreshCcw } from "lucide-react";
+import { cn } from "./ui/utils";
+
+interface TradeFeedResponse {
+  casts: TradeCast[];
+  error?: string;
+}
+
+async function fetchTradeCasts(token: string) {
+  const response = await fetch(`/api/tradecasts?token=${encodeURIComponent(token)}`);
+  if (!response.ok) {
+    const message = await response.json().catch(() => ({ error: "Unknown error" }));
+    throw new Error(message.error || "Failed to load tradecasts");
+  }
+  return (await response.json()) as TradeFeedResponse;
+}
+
+const popularTokens = ["degen", "friend", "base", "tosi", "usdc", "eth"];
+
+export function TradeFeed() {
+  const [tokenQuery, setTokenQuery] = useState("degen");
+  const [searchInput, setSearchInput] = useState("degen");
+
+  const { data, isLoading, isError, refetch, error, isFetching } = useQuery({
+    queryKey: ["tradecasts", tokenQuery],
+    queryFn: () => fetchTradeCasts(tokenQuery),
+    refetchInterval: 20_000,
+  });
+
+  const casts = useMemo(() => {
+    const list = data?.casts ? [...data.casts] : [];
+    return list.sort((a, b) => b.trade.timestamp - a.trade.timestamp);
+  }, [data]);
+
+  return (
+    <section className="flex flex-1 flex-col gap-6">
+      <header className="rounded-3xl border border-white/10 bg-black/30 p-6 shadow-xl shadow-black/50">
+        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-2">
+            <h2 className="text-2xl font-semibold">Live TradeCasts</h2>
+            <p className="max-w-xl text-sm text-white/70">
+              Pull the freshest onchain trades into a Farcaster-ready mini feed. Type a Base token, pair, or wallet, then
+              mirror the moves that matter.
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <form
+              className="flex w-full items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm shadow-inner"
+              onSubmit={(event) => {
+                event.preventDefault();
+                if (!searchInput.trim()) return;
+                setTokenQuery(searchInput.trim());
+              }}
+            >
+              <input
+                value={searchInput}
+                onChange={(event) => setSearchInput(event.target.value)}
+                placeholder="Try degen, friend.tech, or a Base wallet"
+                className="flex-1 bg-transparent outline-none placeholder:text-white/40"
+              />
+              <button
+                type="submit"
+                className="rounded-full bg-primary px-4 py-1 text-sm font-semibold text-primary-foreground transition hover:shadow-glow"
+              >
+                Cast it
+              </button>
+            </form>
+            <button
+              onClick={() => refetch()}
+              className={cn(
+                "inline-flex items-center justify-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-white/70 transition hover:border-white/40",
+                isFetching && "animate-pulse",
+              )}
+            >
+              <RefreshCcw size={16} /> Refresh
+            </button>
+          </div>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2 text-xs">
+          {popularTokens.map((token) => (
+            <button
+              key={token}
+              onClick={() => {
+                setSearchInput(token);
+                setTokenQuery(token);
+              }}
+              className={cn(
+                "rounded-full border border-white/10 px-3 py-1 uppercase tracking-wide transition",
+                tokenQuery === token ? "bg-primary text-primary-foreground" : "bg-white/5 text-white/70 hover:border-white/30",
+              )}
+            >
+              #{token}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {isLoading ? (
+        <div className="grid gap-5 md:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="h-60 animate-pulse rounded-3xl bg-white/5" />
+          ))}
+        </div>
+      ) : isError ? (
+        <div className="rounded-3xl border border-red-400/40 bg-red-500/10 p-6 text-sm text-red-100">
+          {error instanceof Error ? error.message : "Unable to load tradecasts. Try again soon."}
+        </div>
+      ) : casts.length > 0 ? (
+        <div className="grid gap-5 md:grid-cols-2">
+          {casts.map((cast) => (
+            <TradeCastCard key={cast.id} cast={cast} />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/70">
+          No trades found yet. Try another token, or connect a wallet in the composer to log your own onchain move.
+        </div>
+      )}
+    </section>
+  );
+}

--- a/components/trade-form.tsx
+++ b/components/trade-form.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { formatTokenAmount, formatUsd } from "@/lib/format";
+import { cn } from "./ui/utils";
+import { TradeMirrorPreset } from "@/lib/types";
+
+const mirrorPresets: TradeMirrorPreset[] = [
+  {
+    name: "Uniswap",
+    description: "Open a swap on Base with your inputs prefilled.",
+    url: "https://app.uniswap.org/swap?chain=base",
+  },
+  {
+    name: "Aerodrome",
+    description: "Send people straight to Aerodrome's Base pools.",
+    url: "https://aerodrome.finance/swap",
+  },
+  {
+    name: "Beam Mirror",
+    description: "Trigger a Farcaster frame that mirrors the trade.",
+    url: "https://warpcast.com/~/compose?text=Mirroring%20this%20trade",
+  },
+];
+
+export function TradeComposer() {
+  const [tokenSymbol, setTokenSymbol] = useState("DEGEN");
+  const [network, setNetwork] = useState("base");
+  const [direction, setDirection] = useState<"buy" | "sell">("buy");
+  const [amountToken, setAmountToken] = useState(0.2);
+  const [amountUsd, setAmountUsd] = useState(120);
+  const [txHash, setTxHash] = useState("0x1234...abcd");
+  const [wallet, setWallet] = useState("0xF39a...cB00");
+
+  const castCopy = useMemo(() => {
+    const action = direction === "buy" ? "Bought" : "Sold";
+    return `${action} ${formatTokenAmount(amountToken)} ${tokenSymbol} on ${network} (${formatUsd(amountUsd)}) #TradeCast`;
+  }, [direction, amountToken, tokenSymbol, network, amountUsd]);
+
+  return (
+    <aside className="space-y-6">
+      <div className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-black/40">
+        <h2 className="text-xl font-semibold">Compose a TradeCast</h2>
+        <p className="mt-2 text-sm text-white/70">
+          Pull in your latest Base move or draft a hypothetical trade. When you post, the cast bundles proof links and a
+          mirror button other users can slam.
+        </p>
+
+        <form className="mt-6 space-y-4 text-sm">
+          <div className="grid gap-3">
+            <label className="text-xs uppercase tracking-wide text-white/40">Token</label>
+            <input
+              className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3"
+              value={tokenSymbol}
+              onChange={(event) => setTokenSymbol(event.target.value.toUpperCase())}
+              placeholder="DEGEN"
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="grid gap-3">
+              <label className="text-xs uppercase tracking-wide text-white/40">Direction</label>
+              <div className="grid grid-cols-2 gap-2">
+                {(["buy", "sell"] as const).map((option) => (
+                  <button
+                    type="button"
+                    key={option}
+                    onClick={() => setDirection(option)}
+                    className={cn(
+                      "rounded-2xl border border-white/10 px-3 py-2 transition",
+                      direction === option ? "bg-primary text-primary-foreground" : "bg-black/30 text-white/70 hover:border-white/30",
+                    )}
+                  >
+                    {option === "buy" ? "Buy" : "Sell"}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="grid gap-3">
+              <label className="text-xs uppercase tracking-wide text-white/40">Network</label>
+              <select
+                className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3"
+                value={network}
+                onChange={(event) => setNetwork(event.target.value)}
+              >
+                <option value="base">Base</option>
+                <option value="optimism">Optimism</option>
+                <option value="zora">Zora</option>
+                <option value="mainnet">Mainnet</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="grid gap-3">
+              <label className="text-xs uppercase tracking-wide text-white/40">Amount (token)</label>
+              <input
+                type="number"
+                min="0"
+                step="0.0001"
+                className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3"
+                value={amountToken}
+                onChange={(event) => setAmountToken(Number(event.target.value))}
+              />
+            </div>
+            <div className="grid gap-3">
+              <label className="text-xs uppercase tracking-wide text-white/40">Amount (USD)</label>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3"
+                value={amountUsd}
+                onChange={(event) => setAmountUsd(Number(event.target.value))}
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-3">
+            <label className="text-xs uppercase tracking-wide text-white/40">Transaction hash</label>
+            <input
+              className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3"
+              value={txHash}
+              onChange={(event) => setTxHash(event.target.value)}
+              placeholder="0xabc..."
+            />
+          </div>
+
+          <div className="grid gap-3">
+            <label className="text-xs uppercase tracking-wide text-white/40">Wallet</label>
+            <input
+              className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3"
+              value={wallet}
+              onChange={(event) => setWallet(event.target.value)}
+              placeholder="0x123..."
+            />
+          </div>
+        </form>
+      </div>
+
+      <div className="rounded-3xl border border-primary/30 bg-primary/10 p-6 text-sm text-white/80">
+        <h3 className="text-lg font-semibold text-primary-foreground">Cast preview</h3>
+        <p className="mt-4 whitespace-pre-wrap rounded-2xl border border-primary/30 bg-black/30 px-4 py-3 text-sm font-mono text-primary-foreground">
+          {castCopy}
+
+Proof: https://basescan.org/tx/{txHash}
+Wallet: {wallet}
+        </p>
+        <p className="mt-3 text-xs text-primary-foreground/70">
+          Drop this text into Warpcast or plug it into a Frame composer. TradeCast Mini Apps can also ingest this payload over
+          Farcaster JSON.
+        </p>
+      </div>
+
+      <div className="rounded-3xl border border-white/10 bg-black/40 p-6">
+        <h3 className="text-lg font-semibold">Mirror buttons</h3>
+        <p className="mt-2 text-sm text-white/70">
+          Attach a CTA that lets your followers jump into the same trade. These URLs power the button inside Warpcast Frames
+          or Monad mini apps.
+        </p>
+        <ul className="mt-4 space-y-3 text-sm">
+          {mirrorPresets.map((preset) => (
+            <li key={preset.name} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="font-semibold text-white">{preset.name}</p>
+                  <p className="text-xs text-white/60">{preset.description}</p>
+                </div>
+                <a
+                  className="rounded-full bg-primary px-3 py-1 text-xs font-semibold text-primary-foreground"
+                  href={preset.url}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Copy URL
+                </a>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
+  );
+}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,18 @@
+import { cn } from "./utils";
+import { HTMLAttributes } from "react";
+
+export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("rounded-3xl border border-white/10 bg-white/10 backdrop-blur", className)} {...props} />;
+}
+
+export function CardHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("rounded-t-3xl", className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("rounded-b-3xl", className)} {...props} />;
+}
+
+export function CardTitle({ className, ...props }: HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={cn("text-xl font-semibold", className)} {...props} />;
+}

--- a/components/ui/utils.ts
+++ b/components/ui/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/lib/dexscreener.ts
+++ b/lib/dexscreener.ts
@@ -1,0 +1,132 @@
+import { TradeCast, TradeCastChartPoint, TradeCastPairMeta, TradeCastTrade } from "./types";
+
+interface DexScreenerPair {
+  chainId: string;
+  pairAddress: string;
+  dexId: string;
+  url: string;
+  baseToken: {
+    address: string;
+    name: string;
+    symbol: string;
+  };
+}
+
+interface DexScreenerTrade {
+  txId?: string;
+  txHash?: string;
+  priceUsd: string | number;
+  amountUsd: string | number;
+  amountToken?: string | number;
+  amountNative?: string | number;
+  timestamp: number;
+  side: "buy" | "sell";
+  maker: string;
+}
+
+const DEXSCREENER_BASE_URL = "https://api.dexscreener.com/latest/dex";
+const GECKOTERMINAL_BASE_URL = "https://api.geckoterminal.com/api/v2";
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      "User-Agent": "TradeCast/1.0 (+https://base.org)",
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+    next: { revalidate: 15 },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export async function searchPairsByToken(query: string) {
+  const data = await fetchJson<{ pairs: DexScreenerPair[] }>(
+    `${DEXSCREENER_BASE_URL}/search?q=${encodeURIComponent(query)}`,
+  );
+
+  return data.pairs ?? [];
+}
+
+export async function fetchRecentTrades(pair: DexScreenerPair, limit = 5) {
+  const { chainId, pairAddress } = pair;
+  const data = await fetchJson<{ trades: DexScreenerTrade[] }>(
+    `${DEXSCREENER_BASE_URL}/trades/${chainId}/${pairAddress}?limit=${limit}`,
+  );
+
+  return (data.trades ?? []).map((trade) => ({
+    ...trade,
+    priceUsd: Number(trade.priceUsd ?? 0),
+    amountUsd: Number(trade.amountUsd ?? 0),
+    amountToken: Number(trade.amountToken ?? trade.amountNative ?? 0),
+  }));
+}
+
+export async function fetchChartPoints(pair: DexScreenerPair, range = 12) {
+  try {
+    const { chainId, pairAddress } = pair;
+    const data = await fetchJson<{ data: { attributes: { ohlcv_list: [number, string][] } } }>(
+      `${GECKOTERMINAL_BASE_URL}/networks/${chainId}/pools/${pairAddress}/ohlcv/hour?aggregate=1&limit=${range}`,
+    );
+
+    const ohlcv = data?.data?.attributes?.ohlcv_list ?? [];
+
+    const points: TradeCastChartPoint[] = ohlcv.map(([time, price]) => ({
+      time: time * 1000,
+      priceUsd: Number(price),
+    }));
+
+    return points;
+  } catch (error) {
+    console.error("chart fetch failed", error);
+    return [];
+  }
+}
+
+export function buildMirrorUrl(pair: DexScreenerPair) {
+  if (pair.chainId === "base") {
+    return `https://app.uniswap.org/swap?chain=base&outputCurrency=${pair.baseToken.address}`;
+  }
+  return pair.url;
+}
+
+export function toTradeCast(
+  pair: DexScreenerPair,
+  trade: DexScreenerTrade,
+  chart?: TradeCastChartPoint[],
+): TradeCast {
+  const txHash = trade.txId ?? trade.txHash ?? "";
+
+  const meta: TradeCastPairMeta = {
+    tokenSymbol: pair.baseToken.symbol,
+    tokenName: pair.baseToken.name,
+    tokenAddress: pair.baseToken.address,
+    network: pair.chainId,
+    pairAddress: pair.pairAddress,
+    dexUrl: pair.url,
+  };
+
+  const tradeMeta: TradeCastTrade = {
+    direction: trade.side,
+    amountToken: Number(trade.amountToken ?? 0),
+    amountUsd: Number(trade.amountUsd ?? 0),
+    priceUsd: Number(trade.priceUsd ?? 0),
+    timestamp: trade.timestamp * 1000,
+    txHash,
+    trader: trade.maker,
+  };
+
+  return {
+    id: `${pair.pairAddress}-${txHash}`,
+    pair: meta,
+    trade: tradeMeta,
+    proofUrl: `https://basescan.org/tx/${txHash}`,
+    mirrorUrl: buildMirrorUrl(pair),
+    chart,
+  };
+}

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,34 @@
+import { formatDistanceToNowStrict } from "date-fns";
+
+export function formatUsd(value: number) {
+  if (!Number.isFinite(value)) return "$0.00";
+  if (Math.abs(value) >= 1000) {
+    return `$${value.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+  }
+  return `$${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+}
+
+export function formatTokenAmount(value: number) {
+  if (!Number.isFinite(value)) return "0";
+  if (Math.abs(value) >= 1000) {
+    return value.toLocaleString(undefined, { maximumFractionDigits: 0 });
+  }
+  if (Math.abs(value) >= 1) {
+    return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  }
+  return value.toLocaleString(undefined, { maximumFractionDigits: 4 });
+}
+
+export function formatRelativeTime(timestamp: number) {
+  if (!timestamp) return 'just now';
+  return formatDistanceToNowStrict(new Date(timestamp), { addSuffix: true });
+}
+
+export function shortenAddress(address: string, chars = 4) {
+  if (!address) return "unknown";
+  return `${address.slice(0, chars + 2)}…${address.slice(-chars)}`;
+}
+
+export function shortenHash(hash: string) {
+  return shortenAddress(hash, 6);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,40 @@
+export type TradeDirection = "buy" | "sell";
+
+export interface TradeCastTrade {
+  direction: TradeDirection;
+  amountToken: number;
+  amountUsd: number;
+  priceUsd: number;
+  timestamp: number;
+  txHash: string;
+  trader: string;
+}
+
+export interface TradeCastPairMeta {
+  tokenSymbol: string;
+  tokenName: string;
+  tokenAddress: string;
+  network: string;
+  pairAddress: string;
+  dexUrl?: string;
+}
+
+export interface TradeCastChartPoint {
+  time: number;
+  priceUsd: number;
+}
+
+export interface TradeCast {
+  id: string;
+  pair: TradeCastPairMeta;
+  trade: TradeCastTrade;
+  proofUrl: string;
+  mirrorUrl?: string;
+  chart?: TradeCastChartPoint[];
+}
+
+export interface TradeMirrorPreset {
+  name: string;
+  description: string;
+  url: string;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,14 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    turbo: {
+      rules: {
+        '*.svg': {
+          loaders: ['@svgr/webpack'],
+        },
+      },
+    },
+  },
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "tradecast-v1",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "5.62.4",
+    "class-variance-authority": "0.7.0",
+    "clsx": "2.1.0",
+    "date-fns": "3.6.0",
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "recharts": "2.12.7",
+    "tailwind-merge": "2.4.0",
+    "lucide-react": "0.453.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.9",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "10.4.19",
+    "postcss": "8.4.38",
+    "tailwindcss": "3.4.7",
+    "typescript": "5.4.5"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,26 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: "#5D6BFF",
+          foreground: "#F5F7FF",
+        },
+        accent: "#F6C177",
+        surface: "#0B0E1A",
+      },
+      boxShadow: {
+        glow: "0 0 45px rgba(93, 107, 255, 0.45)",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.d.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js + Tailwind TradeCast experience with hero messaging, highlights, and roadmap for the Farcaster concept
- implement a live trade feed that hits DexScreener and GeckoTerminal APIs and renders proof-rich cards with mirroring CTAs
- add a TradeCast composer, shared UI primitives, and formatting utilities to prepare cast text, mirror presets, and price snapshots

## Testing
- npm install *(fails: 403 Forbidden from npm registry in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ede57eb08325afb81046b3004cac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced TradeCast landing page with hero, “How it works,” highlights, and roadmap.
  - Added live Trade Feed with search, quick tokens, manual refresh, and auto-refresh.
  - Added Trade Cast cards with price chart, onchain proof, mirror, and pair links.
  - Added Trade Composer to draft casts with network, direction, amounts, wallet, and mirror presets.
  - Provided public API endpoint to fetch casts by token.
- Style
  - New global dark theme, gradients, and card UI components.
- Documentation
  - Expanded README with clearer intro, features, setup, API, and deployment.
- Chores
  - Initial project/config setup for Next.js, Tailwind, TypeScript.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->