### PR TITLE
Add multi-chain infrastructure for TradeCast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # TradeCast-V1
-A tradecasting system on Farcaster
+
+A tradecasting system on Farcaster.
+
+## Multi-chain support
+
+This repository now includes a lightweight Python module that lets TradeCast
+interact with multiple EVM-compatible chains through JSON-RPC calls. Chains are
+configured through JSON files and loaded into a registry that the `TradeCast`
+class uses to broadcast transactions or execute queries on multiple networks at
+once.
+
+### Getting started
+
+1. Create a virtual environment and install dependencies (there are no external
+   dependencies for the base module, but you can install `pytest` if you want to
+   run the unit tests).
+2. Populate `chains/default_chains.json` with the RPC URLs that you want to use.
+3. Use the module in your scripts:
+
+```python
+from pathlib import Path
+from tradecast import TradeCast, load_chains_from_file
+
+registry = load_chains_from_file(Path("chains/default_chains.json"))
+client = TradeCast(registry)
+
+# Fetch the latest block numbers across all chains
+block_numbers = client.fetch_latest_block_numbers()
+print(block_numbers)
+
+# Broadcast a signed raw transaction to a subset of chains
+raw_tx = "0x..."
+response = client.broadcast_raw_transaction(raw_tx, chains=["Ethereum", "Polygon"])
+print(response)
+```
+
+### Testing
+
+To run the tests (optional):
+
+```bash
+pytest
+```

--- a/chains/default_chains.json
+++ b/chains/default_chains.json
@@ -1,0 +1,26 @@
+[
+    {
+        "name": "Ethereum",
+        "chain_id": 1,
+        "rpc_url": "https://mainnet.infura.io/v3/your-project-id",
+        "currency_symbol": "ETH",
+        "explorer_url": "https://etherscan.io",
+        "tags": ["mainnet", "evm"]
+    },
+    {
+        "name": "Polygon",
+        "chain_id": 137,
+        "rpc_url": "https://polygon-rpc.com",
+        "currency_symbol": "MATIC",
+        "explorer_url": "https://polygonscan.com",
+        "tags": ["evm", "sidechain"]
+    },
+    {
+        "name": "Base",
+        "chain_id": 8453,
+        "rpc_url": "https://mainnet.base.org",
+        "currency_symbol": "ETH",
+        "explorer_url": "https://basescan.org",
+        "tags": ["evm", "l2"]
+    }
+]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+import json
+import sys
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tradecast.chains.chain import ChainMetadata
+from tradecast.chains.registry import ChainRegistry, load_chains_from_file, load_chains_from_dict
+
+
+def test_chain_metadata_roundtrip():
+    metadata = ChainMetadata(
+        name="TestChain",
+        chain_id=999,
+        rpc_url="https://example.com",
+        currency_symbol="TST",
+        explorer_url="https://explorer.example.com",
+        tags=("test", "evm"),
+    )
+    payload = metadata.to_dict()
+    reconstructed = ChainMetadata.from_dict(payload)
+    assert reconstructed == metadata
+
+
+def test_registry_register_and_get():
+    registry = ChainRegistry()
+    registry.register(
+        ChainMetadata(
+            name="ChainA", chain_id=1, rpc_url="https://a", currency_symbol="A"
+        )
+    )
+    assert registry.get("ChainA").chain_id == 1
+
+    with pytest.raises(ValueError):
+        registry.register(
+            ChainMetadata(
+                name="ChainA", chain_id=2, rpc_url="https://b", currency_symbol="B"
+            )
+        )
+
+    with pytest.raises(KeyError):
+        registry.get("unknown")
+
+
+def test_load_chains_from_dict():
+    registry = load_chains_from_dict(
+        [
+            {"name": "A", "chain_id": 1, "rpc_url": "https://a", "currency_symbol": "A"},
+            {"name": "B", "chain_id": 2, "rpc_url": "https://b", "currency_symbol": "B"},
+        ]
+    )
+    assert len(list(registry)) == 2
+
+
+def test_load_chains_from_file(tmp_path: Path):
+    config = [
+        {"name": "A", "chain_id": 1, "rpc_url": "https://a", "currency_symbol": "A"},
+        {"name": "B", "chain_id": 2, "rpc_url": "https://b", "currency_symbol": "B"},
+    ]
+    config_path = tmp_path / "chains.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    registry = load_chains_from_file(config_path)
+    assert registry.get("A").chain_id == 1
+    assert registry.get("B").chain_id == 2
+
+
+def test_tradecast_fetch_latest_block_numbers(monkeypatch):
+    from tradecast.multichain import TradeCast
+
+    chains = [
+        {"name": "ChainA", "chain_id": 1, "rpc_url": "https://a", "currency_symbol": "A"},
+        {"name": "ChainB", "chain_id": 2, "rpc_url": "https://b", "currency_symbol": "B"},
+    ]
+    registry = load_chains_from_dict(chains)
+    client = TradeCast(registry)
+
+    calls = []
+
+    class FakeClient:
+        def __init__(self, url, timeout=None):
+            self.url = url
+            self.timeout = timeout
+
+        def call(self, method, params=None):
+            calls.append((self.url, method, tuple(params or [])))
+            return "0x10"
+
+    monkeypatch.setattr("tradecast.multichain.JsonRpcClient", FakeClient)
+
+    result = client.fetch_latest_block_numbers()
+    assert result == {"ChainA": 16, "ChainB": 16}
+    assert len(calls) == 2
+    assert calls[0][1] == "eth_blockNumber"

--- a/tradecast/__init__.py
+++ b/tradecast/__init__.py
@@ -1,0 +1,10 @@
+"""TradeCast multi-chain support package."""
+
+from .chains.registry import ChainRegistry, load_chains_from_file
+from .multichain import TradeCast
+
+__all__ = [
+    "ChainRegistry",
+    "TradeCast",
+    "load_chains_from_file",
+]

--- a/tradecast/chains/__init__.py
+++ b/tradecast/chains/__init__.py
@@ -1,0 +1,11 @@
+"""Chain utilities for TradeCast."""
+
+from .chain import ChainMetadata
+from .registry import ChainRegistry, load_chains_from_dict, load_chains_from_file
+
+__all__ = [
+    "ChainMetadata",
+    "ChainRegistry",
+    "load_chains_from_dict",
+    "load_chains_from_file",
+]

--- a/tradecast/chains/chain.py
+++ b/tradecast/chains/chain.py
@@ -1,0 +1,66 @@
+"""Chain metadata representation for TradeCast."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Optional
+
+
+@dataclass(frozen=True)
+class ChainMetadata:
+    """Describes a blockchain supported by TradeCast.
+
+    Attributes:
+        name: Human readable chain name (e.g. "Ethereum").
+        chain_id: EVM chain id as an integer.
+        rpc_url: HTTPS endpoint for JSON-RPC calls.
+        currency_symbol: Symbol of the native token (e.g. "ETH").
+        explorer_url: Optional base URL for the chain's block explorer.
+        tags: Optional set of free-form tags describing the chain.
+    """
+
+    name: str
+    chain_id: int
+    rpc_url: str
+    currency_symbol: str
+    explorer_url: Optional[str] = None
+    tags: Iterable[str] = field(default_factory=tuple)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Return a serialisable dictionary representation."""
+
+        return {
+            "name": self.name,
+            "chain_id": self.chain_id,
+            "rpc_url": self.rpc_url,
+            "currency_symbol": self.currency_symbol,
+            "explorer_url": self.explorer_url,
+            "tags": list(self.tags),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "ChainMetadata":
+        """Create :class:`ChainMetadata` from a dictionary."""
+
+        missing_keys = {"name", "chain_id", "rpc_url", "currency_symbol"} - data.keys()
+        if missing_keys:
+            missing = ", ".join(sorted(missing_keys))
+            raise ValueError(f"Missing required chain keys: {missing}")
+
+        tags_data = data.get("tags")
+        tags: Iterable[str]
+        if tags_data is None:
+            tags = ()
+        elif isinstance(tags_data, (list, tuple, set)):
+            tags = tuple(str(tag) for tag in tags_data)
+        else:
+            raise TypeError("tags must be a sequence of strings")
+
+        return cls(
+            name=str(data["name"]),
+            chain_id=int(data["chain_id"]),
+            rpc_url=str(data["rpc_url"]),
+            currency_symbol=str(data["currency_symbol"]),
+            explorer_url=(None if data.get("explorer_url") is None else str(data["explorer_url"])),
+            tags=tags,
+        )

--- a/tradecast/chains/jsonrpc.py
+++ b/tradecast/chains/jsonrpc.py
@@ -1,0 +1,64 @@
+"""Minimal JSON-RPC client used by TradeCast."""
+
+from __future__ import annotations
+
+import json
+import itertools
+from typing import Any, Iterable, Optional
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+
+class JsonRpcError(RuntimeError):
+    """Raised when a JSON-RPC call fails."""
+
+
+class JsonRpcClient:
+    """Tiny JSON-RPC client suitable for blockchain RPC endpoints."""
+
+    def __init__(self, url: str, *, timeout: Optional[float] = None) -> None:
+        self._url = url
+        self._timeout = timeout
+        self._ids = itertools.count(1)
+
+    def call(self, method: str, params: Optional[Iterable[Any]] = None) -> Any:
+        """Perform a JSON-RPC call against the configured endpoint."""
+
+        request_id = next(self._ids)
+        payload = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": list(params) if params is not None else [],
+            }
+        ).encode("utf-8")
+
+        request = Request(
+            self._url,
+            data=payload,
+            headers={"Content-Type": "application/json", "User-Agent": "TradeCast/1.0"},
+            method="POST",
+        )
+
+        try:
+            with urlopen(request, timeout=self._timeout) as response:
+                body = response.read()
+        except URLError as exc:  # pragma: no cover - network errors in tests
+            raise JsonRpcError(str(exc)) from exc
+
+        try:
+            data = json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError as exc:  # pragma: no cover - dependent on remote data
+            raise JsonRpcError("Invalid JSON-RPC response") from exc
+
+        if isinstance(data, dict) and "error" in data:
+            error = data["error"]
+            if isinstance(error, dict):
+                message = error.get("message", "Unknown error")
+                code = error.get("code")
+                raise JsonRpcError(f"RPC error {code}: {message}")
+            raise JsonRpcError(str(error))
+        if isinstance(data, dict) and "result" in data:
+            return data["result"]
+        raise JsonRpcError("Malformed JSON-RPC response")

--- a/tradecast/chains/registry.py
+++ b/tradecast/chains/registry.py
@@ -1,0 +1,80 @@
+"""Registry and configuration loading helpers for TradeCast chains."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Mapping, MutableMapping
+
+from .chain import ChainMetadata
+
+
+class ChainRegistry:
+    """Stores metadata about chains supported by TradeCast."""
+
+    def __init__(self) -> None:
+        self._chains: Dict[str, ChainMetadata] = {}
+
+    def __contains__(self, name: str) -> bool:  # pragma: no cover - trivial
+        return name.lower() in self._chains
+
+    def __iter__(self) -> Iterator[ChainMetadata]:
+        return iter(self._chains.values())
+
+    def __len__(self) -> int:
+        return len(self._chains)
+
+    def register(self, chain: ChainMetadata) -> None:
+        """Register a new chain with the registry."""
+
+        key = chain.name.lower()
+        if key in self._chains:
+            raise ValueError(f"Chain '{chain.name}' already registered")
+        self._chains[key] = chain
+
+    def get(self, name: str) -> ChainMetadata:
+        """Retrieve metadata for ``name``.
+
+        Args:
+            name: Chain name (case insensitive).
+
+        Returns:
+            Chain metadata.
+
+        Raises:
+            KeyError: If the chain is not registered.
+        """
+
+        key = name.lower()
+        if key not in self._chains:
+            raise KeyError(f"Unknown chain '{name}'")
+        return self._chains[key]
+
+    def to_list(self) -> List[Mapping[str, object]]:
+        """Return a JSON serialisable list of chain metadata."""
+
+        return [chain.to_dict() for chain in self._chains.values()]
+
+
+def load_chains_from_file(path: Path) -> ChainRegistry:
+    """Load chain metadata from a JSON file."""
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise TypeError("Chain configuration must be a list")
+
+    registry = ChainRegistry()
+    for entry in data:
+        if not isinstance(entry, MutableMapping):
+            raise TypeError("Each chain entry must be an object")
+        registry.register(ChainMetadata.from_dict(dict(entry)))
+    return registry
+
+
+def load_chains_from_dict(data: Iterable[Mapping[str, object]]) -> ChainRegistry:
+    """Load chain metadata from an iterable of dictionaries."""
+
+    registry = ChainRegistry()
+    for entry in data:
+        registry.register(ChainMetadata.from_dict(dict(entry)))
+    return registry

--- a/tradecast/multichain.py
+++ b/tradecast/multichain.py
@@ -1,0 +1,106 @@
+"""High level utilities for operating TradeCast across many chains."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Optional
+
+from .chains.chain import ChainMetadata
+from .chains.jsonrpc import JsonRpcClient
+from .chains.registry import ChainRegistry
+
+
+@dataclass
+class RpcCallResult:
+    """Represents the result of invoking a JSON-RPC method."""
+
+    chain: ChainMetadata
+    method: str
+    result: object
+
+
+class TradeCast:
+    """Coordinates broadcasting and querying across multiple chains."""
+
+    def __init__(self, registry: ChainRegistry, *, default_timeout: float = 10.0) -> None:
+        self._registry = registry
+        self._default_timeout = default_timeout
+
+    @property
+    def registry(self) -> ChainRegistry:
+        return self._registry
+
+    def available_chains(self) -> List[ChainMetadata]:
+        """Return metadata for all registered chains."""
+
+        return list(self._registry)
+
+    def get_chain(self, name: str) -> ChainMetadata:
+        """Retrieve metadata for a specific chain."""
+
+        return self._registry.get(name)
+
+    def call_rpc(
+        self,
+        method: str,
+        *,
+        chains: Optional[Iterable[str]] = None,
+        params: Optional[Iterable[object]] = None,
+        timeout: Optional[float] = None,
+    ) -> List[RpcCallResult]:
+        """Execute a JSON-RPC method across multiple chains.
+
+        Args:
+            method: JSON-RPC method name.
+            chains: Optional list of chain names. If omitted, call across all
+                registered chains.
+            params: Parameters to send with the RPC call.
+            timeout: Optional request timeout override.
+
+        Returns:
+            List of :class:`RpcCallResult` objects in the order invoked.
+        """
+
+        if chains is None:
+            target_chains = list(self._registry)
+        else:
+            target_chains = [self._registry.get(name) for name in chains]
+
+        call_timeout = timeout if timeout is not None else self._default_timeout
+        results: List[RpcCallResult] = []
+
+        for chain in target_chains:
+            client = JsonRpcClient(chain.rpc_url, timeout=call_timeout)
+            result = client.call(method, params)
+            results.append(RpcCallResult(chain=chain, method=method, result=result))
+        return results
+
+    def broadcast_raw_transaction(
+        self, raw_transaction: str, *, chains: Optional[Iterable[str]] = None, timeout: Optional[float] = None
+    ) -> Dict[str, object]:
+        """Broadcast a signed transaction to multiple chains."""
+
+        responses: Dict[str, object] = {}
+        for call in self.call_rpc(
+            "eth_sendRawTransaction",
+            chains=chains,
+            params=[raw_transaction],
+            timeout=timeout,
+        ):
+            responses[call.chain.name] = call.result
+        return responses
+
+    def fetch_latest_block_numbers(
+        self, *, chains: Optional[Iterable[str]] = None, timeout: Optional[float] = None
+    ) -> Mapping[str, int]:
+        """Return the latest block number for the specified chains."""
+
+        numbers: Dict[str, int] = {}
+        for call in self.call_rpc("eth_blockNumber", chains=chains, timeout=timeout):
+            if isinstance(call.result, str) and call.result.startswith("0x"):
+                numbers[call.chain.name] = int(call.result, 16)
+            elif isinstance(call.result, int):
+                numbers[call.chain.name] = call.result
+            else:  # pragma: no cover - depends on remote RPC implementation
+                raise TypeError(f"Unexpected block number format for {call.chain.name}: {call.result!r}")
+        return numbers


### PR DESCRIPTION
## Summary
- add a Python module that models chain metadata, loads registries from JSON, and exposes a multi-chain TradeCast helper
- include a default chain configuration and documentation explaining how to run multi-chain RPC calls
- add unit tests for the registry and multi-chain helpers plus ignore Python bytecode artifacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4f00a1dd083259271090f1fc96849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Multi-chain support: perform JSON-RPC calls, broadcast signed transactions, and fetch latest block numbers across EVM-compatible networks.
  - Built-in chain registry with three example networks (Ethereum, Polygon, Base) and easy JSON-based loading.

- Documentation
  - README expanded with Python getting-started, usage examples, and multi-chain workflow.

- Tests
  - Added tests covering chain metadata, registry behavior, JSON loading, and multi-chain RPC flows.

- Chores
  - Added .gitignore entries for Python caches/bytecode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->