### PR TITLE
Add Docker deployment configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.next
+out
+.git
+.gitignore
+coverage
+.env
+.env.local
+.env.*
+**/__pycache__
+**/*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,15 @@
 __pycache__/
 *.pyc
+
+# Node / Next.js build artifacts
+node_modules/
+.next/
+out/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.turbo/
+
+# Environment files
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS deps
+WORKDIR /app
+
+# Install dependencies based on the available lockfile (if present)
+COPY package*.json ./
+RUN npm install --include=dev
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN npm run build
+RUN npm prune --omit=dev
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Create non-root user
+RUN addgroup -g 1001 nodejs \
+    && adduser -S -u 1001 -G nodejs nextjs
+
+# Copy necessary files
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+USER nextjs
+EXPOSE 3000
+
+CMD ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -40,4 +40,28 @@ print(block_numbers)
 raw_tx = "0x..."
 response = client.broadcast_raw_transaction(raw_tx, chains=["Ethereum", "Polygon"])
 print(response)
+```
+
+---
+
+## Deployment
+
+TradeCast ships with a production-ready Dockerfile so you can build and run the
+Next.js application anywhere that supports containers.
+
+### Build the image
+
+```bash
+docker build -t tradecast-app .
+```
+
+### Run the container
+
+```bash
+docker run --env-file .env.local -p 3000:3000 tradecast-app
+```
+
+The application will be available at `http://localhost:3000`. Provide any
+required runtime secrets (such as API keys) through an `.env.local` file or
+environment variables that you mount into the container.
 


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile and dockerignore to containerize the Next.js app for production
- document Docker build and run steps in the README
- expand the gitignore to cover Node build artifacts and environment files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4fc0a84708325929daaf9edf4a811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Dockerized application with a production-ready multi-stage image, non-root runtime, and port 3000 exposure.
- Chores
  - Added .dockerignore to reduce Docker build context (e.g., node_modules, logs, env files).
  - Expanded .gitignore to exclude common Node/Next.js artifacts and environment files.
- Documentation
  - Added Deployment section with Docker build/run steps and guidance on providing environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->