### PR TITLE
Add Base TradeReceipt contract and integrate onchain receipts

### DIFF
--- a/components/trade-cast-card.tsx
+++ b/components/trade-cast-card.tsx
@@ -11,7 +11,7 @@ interface TradeCastCardProps {
 }
 
 export function TradeCastCard({ cast }: TradeCastCardProps) {
-  const { pair, trade, proofUrl, mirrorUrl, chart } = cast;
+  const { pair, trade, proofUrl, mirrorUrl, chart, receiptUrl, transactionUrl } = cast;
 
   const chartData = useMemo(
     () =>
@@ -81,8 +81,18 @@ export function TradeCastCard({ cast }: TradeCastCardProps) {
               target="_blank"
               rel="noreferrer"
             >
-              Onchain proof {shortenHash(trade.txHash)}
+              {receiptUrl ? "Receipt log" : "Onchain proof"} {shortenHash(trade.txHash)}
             </a>
+            {receiptUrl && transactionUrl ? (
+              <a
+                className="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 transition hover:border-white/40"
+                href={transactionUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Trade tx
+              </a>
+            ) : null}
             {mirrorUrl ? (
               <a
                 className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-1 text-sm font-semibold text-primary-foreground transition hover:shadow-glow"

--- a/contracts/TradeReceipt.sol
+++ b/contracts/TradeReceipt.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title TradeReceipt
+/// @notice Emits immutable onchain receipts for TradeCast payloads so casts can cite
+///         an event log that survives beyond third-party APIs.
+contract TradeReceipt {
+    /// @notice Emitted when a trade payload is notarized.
+    /// @param submitter Address that notarized the payload.
+    /// @param tradeTxHash Transaction hash of the underlying onchain trade being notarized.
+    /// @param payloadHash Keccak-256 hash of the plaintext payload for quick comparisons.
+    /// @param payload Full plaintext payload that can be rendered in Warpcast or a frame.
+    /// @param timestamp Block timestamp when the payload was notarized.
+    event TradeNotarized(
+        address indexed submitter,
+        bytes32 indexed tradeTxHash,
+        bytes32 indexed payloadHash,
+        string payload,
+        uint256 timestamp
+    );
+
+    /// @notice Notarize a trade payload by emitting an event containing its metadata.
+    /// @dev Returns the payload hash so callers can surface it in the UI immediately.
+    /// @param tradeTxHash Transaction hash of the original trade on Base.
+    /// @param payload The plaintext payload that should be preserved onchain.
+    /// @return payloadHash Hash of the payload that is also indexed in the event topics.
+    function notarize(bytes32 tradeTxHash, string calldata payload)
+        external
+        returns (bytes32 payloadHash)
+    {
+        payloadHash = keccak256(bytes(payload));
+        emit TradeNotarized(msg.sender, tradeTxHash, payloadHash, payload, block.timestamp);
+    }
+}

--- a/lib/dexscreener.ts
+++ b/lib/dexscreener.ts
@@ -1,4 +1,5 @@
 import { TradeCast, TradeCastChartPoint, TradeCastPairMeta, TradeCastTrade } from "./types";
+import { buildTradeReceiptUrl } from "./notary";
 
 interface DexScreenerPair {
   chainId: string;
@@ -121,11 +122,17 @@ export function toTradeCast(
     trader: trade.maker,
   };
 
+  const receiptUrl = buildTradeReceiptUrl(txHash);
+  const transactionUrl = txHash ? `https://basescan.org/tx/${txHash}` : undefined;
+  const proofUrl = receiptUrl ?? transactionUrl ?? pair.url;
+
   return {
     id: `${pair.pairAddress}-${txHash}`,
     pair: meta,
     trade: tradeMeta,
-    proofUrl: `https://basescan.org/tx/${txHash}`,
+    proofUrl,
+    receiptUrl,
+    transactionUrl,
     mirrorUrl: buildMirrorUrl(pair),
     chart,
   };

--- a/lib/notary.ts
+++ b/lib/notary.ts
@@ -1,0 +1,34 @@
+import { keccak256, stringToHex } from "viem";
+
+const NOTARY_EVENT_SIGNATURE = "TradeNotarized(address,bytes32,bytes32,string,uint256)";
+const TRADE_NOTARIZED_TOPIC = keccak256(stringToHex(NOTARY_EVENT_SIGNATURE));
+
+const RECEIPT_ADDRESS = process.env.NEXT_PUBLIC_TRADE_RECEIPT_ADDRESS?.toLowerCase();
+const BASESCAN_ADDRESS = "https://basescan.org";
+
+function normalizeTxHash(hash: string | undefined | null) {
+  if (!hash) return undefined;
+  const trimmed = hash.trim();
+  if (!trimmed) return undefined;
+  return trimmed.startsWith("0x") ? trimmed.toLowerCase() : `0x${trimmed.toLowerCase()}`;
+}
+
+export function getReceiptContractAddress() {
+  return RECEIPT_ADDRESS;
+}
+
+export function getTradeNotarizedTopic() {
+  return TRADE_NOTARIZED_TOPIC;
+}
+
+export function buildTradeReceiptUrl(txHash: string | undefined | null) {
+  if (!RECEIPT_ADDRESS) return undefined;
+  const normalizedHash = normalizeTxHash(txHash);
+  if (!normalizedHash) return undefined;
+
+  const address = RECEIPT_ADDRESS;
+  const topic0 = TRADE_NOTARIZED_TOPIC;
+  const topic1 = normalizedHash;
+
+  return `${BASESCAN_ADDRESS}/address/${address}#eventlog#address=${address}&topic0=${topic0}&topic1=${topic1}`;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -29,6 +29,8 @@ export interface TradeCast {
   pair: TradeCastPairMeta;
   trade: TradeCastTrade;
   proofUrl: string;
+  receiptUrl?: string;
+  transactionUrl?: string;
   mirrorUrl?: string;
   chart?: TradeCastChartPoint[];
 }

--- a/package.json
+++ b/package.json
@@ -6,19 +6,23 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "deploy:receipt": "node scripts/deploy-trade-receipt.mjs"
   },
   "dependencies": {
     "@tanstack/react-query": "5.62.4",
     "class-variance-authority": "0.7.0",
     "clsx": "2.1.0",
     "date-fns": "3.6.0",
+    "dotenv": "16.4.5",
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "recharts": "2.12.7",
     "tailwind-merge": "2.4.0",
-    "lucide-react": "0.453.0"
+    "lucide-react": "0.453.0",
+    "solc": "0.8.26-fixed",
+    "viem": "2.13.6"
   },
   "devDependencies": {
     "@types/node": "20.14.9",

--- a/scripts/deploy-trade-receipt.mjs
+++ b/scripts/deploy-trade-receipt.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import dotenv from "dotenv";
+import solc from "solc";
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  keccak256,
+  stringToHex,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { base } from "viem/chains";
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const CONTRACT_NAME = "TradeReceipt";
+const SOURCE_PATH = path.resolve(__dirname, "../contracts/TradeReceipt.sol");
+
+async function compileContract() {
+  const source = await fs.readFile(SOURCE_PATH, "utf8");
+  const input = {
+    language: "Solidity",
+    sources: {
+      "TradeReceipt.sol": { content: source },
+    },
+    settings: {
+      optimizer: { enabled: true, runs: 200 },
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  const contract = output.contracts?.["TradeReceipt.sol"]?.[CONTRACT_NAME];
+
+  if (!contract?.abi || !contract?.evm?.bytecode?.object) {
+    throw new Error("Failed to compile TradeReceipt contract");
+  }
+
+  return {
+    abi: contract.abi,
+    bytecode: `0x${contract.evm.bytecode.object}`,
+  };
+}
+
+async function main() {
+  const privateKey = process.env.DEPLOYER_PRIVATE_KEY;
+  if (!privateKey) {
+    throw new Error("Missing DEPLOYER_PRIVATE_KEY environment variable");
+  }
+
+  const rpcUrl = process.env.BASE_RPC_URL ?? base.rpcUrls.public.http[0];
+
+  const account = privateKeyToAccount(privateKey.startsWith("0x") ? privateKey : `0x${privateKey}`);
+  const walletClient = createWalletClient({ account, chain: base, transport: http(rpcUrl) });
+  const publicClient = createPublicClient({ chain: base, transport: http(rpcUrl) });
+
+  const { abi, bytecode } = await compileContract();
+
+  console.log(`Deploying ${CONTRACT_NAME} to Base using ${account.address}...`);
+
+  const hash = await walletClient.deployContract({ abi, bytecode, account });
+  console.log(`Transaction hash: ${hash}`);
+
+  const receipt = await publicClient.waitForTransactionReceipt({ hash });
+  if (!receipt.contractAddress) {
+    throw new Error("Deployment transaction mined but contract address missing");
+  }
+
+  const eventTopic = keccak256(stringToHex("TradeNotarized(address,bytes32,bytes32,string,uint256)"));
+
+  const deploymentInfo = {
+    address: receipt.contractAddress,
+    transactionHash: hash,
+    eventSignature: "TradeNotarized(address,bytes32,bytes32,string,uint256)",
+    eventTopic,
+    deployedAt: Date.now(),
+  };
+
+  const outputPath = path.resolve(__dirname, "../contracts/deployments/base-trade-receipt.json");
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, `${JSON.stringify(deploymentInfo, null, 2)}\n`);
+
+  console.log(`TradeReceipt deployed at ${receipt.contractAddress}`);
+  console.log(`Deployment info written to ${outputPath}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a lightweight TradeReceipt Solidity contract and deployment script for notarising TradeCast payloads on Base
- surface contract receipt links throughout the TradeCast UI while keeping transaction fallbacks when the notary is absent
- document deployment steps and expose helpers so the app can reference the notary contract and event topics

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2freact-query)*

------
https://chatgpt.com/codex/tasks/task_e_68e5514a4b288325abaec9ce6ccd7b6f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Display on-chain “Receipt log” link and “Trade tx” link in TradeCast cards when available.
  - Generate receipt and transaction links automatically from trade data.
  - Cast preview now shows dynamic proof info and highlights the live receipt address when configured.

- Documentation
  - Added “Onchain trade receipts” guide with setup, deployment, and usage instructions.

- Chores
  - Added deployment script and new dependencies to support contract deployment and receipt URL generation.
  - Introduced a contract for notarizing TradeCast payloads on Base.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->