### PR TITLE
Add Base TradeReceipt deployment details

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,3 @@
+# Public environment variables consumed by the Next.js app
+# To disable the notarized receipt link entirely set the value to "disabled".
+NEXT_PUBLIC_TRADE_RECEIPT_ADDRESS=0xaf94ad1a7c0c9f3f988217c46dca5ea4665f57c0

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ yarn-error.log*
 
 # Environment files
 .env*
+!.env.local.example

--- a/README.md
+++ b/README.md
@@ -90,7 +90,15 @@ records the trade payload and a pointer to the original trade transaction via an
    `contracts/deployments/base-trade-receipt.json`.
 
 3. Expose the deployed address to the Next.js application so casts can link to the
-   notarised log by setting `NEXT_PUBLIC_TRADE_RECEIPT_ADDRESS` in `.env.local`.
+   notarised log by setting `NEXT_PUBLIC_TRADE_RECEIPT_ADDRESS` in `.env.local` (see
+   `.env.local.example` for a ready-to-use template).
+
+### Production deployment
+
+TradeCast is already deployed on Base at `0xaf94ad1a7c0c9f3f988217c46dca5ea4665f57c0`.
+The web client falls back to this address automatically, so you only need to override
+`NEXT_PUBLIC_TRADE_RECEIPT_ADDRESS` if you ship your own copy or want to disable the
+feature (set the value to `disabled`).
 
 ### Creating a receipt
 

--- a/contracts/deployments/base-trade-receipt.json
+++ b/contracts/deployments/base-trade-receipt.json
@@ -1,0 +1,7 @@
+{
+  "network": "base-mainnet",
+  "address": "0xaf94ad1a7c0c9f3f988217c46dca5ea4665f57c0",
+  "eventSignature": "TradeNotarized(address,bytes32,bytes32,string,uint256)",
+  "notes": "Production TradeReceipt deployment referenced by the web client.",
+  "updatedAt": "2024-10-07T00:00:00.000Z"
+}

--- a/lib/notary.ts
+++ b/lib/notary.ts
@@ -3,7 +3,20 @@ import { keccak256, stringToHex } from "viem";
 const NOTARY_EVENT_SIGNATURE = "TradeNotarized(address,bytes32,bytes32,string,uint256)";
 const TRADE_NOTARIZED_TOPIC = keccak256(stringToHex(NOTARY_EVENT_SIGNATURE));
 
-const RECEIPT_ADDRESS = process.env.NEXT_PUBLIC_TRADE_RECEIPT_ADDRESS?.toLowerCase();
+const FALLBACK_RECEIPT_ADDRESS = "0xaf94ad1a7c0c9f3f988217c46dca5ea4665f57c0";
+
+function normalizeAddress(value: string | undefined | null) {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.startsWith("0x") ? trimmed.toLowerCase() : `0x${trimmed.toLowerCase()}`;
+}
+
+const rawReceiptAddress = process.env.NEXT_PUBLIC_TRADE_RECEIPT_ADDRESS;
+const RECEIPT_ADDRESS =
+  rawReceiptAddress?.trim().toLowerCase() === "disabled"
+    ? undefined
+    : normalizeAddress(rawReceiptAddress) ?? FALLBACK_RECEIPT_ADDRESS;
 const BASESCAN_ADDRESS = "https://basescan.org";
 
 function normalizeTxHash(hash: string | undefined | null) {


### PR DESCRIPTION
## Summary
- default the notarization helpers to the deployed TradeReceipt contract on Base while allowing opt-out
- check in environment template and deployment metadata with the production contract address
- document the live address in the README and ensure the template is committed via .gitignore update

## Testing
- not run (npm install blocked by registry proxy restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68e598c991588325a8ca80b9edc277e2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Trade receipt links are more reliable with improved address and transaction hash validation.
  - Configurable receipt contract address via environment variable, with a safe default fallback.
  - Option to disable the notarized receipt link entirely.

- Documentation
  - Added production deployment guidance, including how to set or disable the receipt address.
  - Provided a ready-to-use environment template reference.

- Chores
  - Included an example environment file in version control for easier setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->