### PR TITLE
Update Base RPC endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ records the trade payload and a pointer to the original trade transaction via an
 
    ```bash
    export DEPLOYER_PRIVATE_KEY=0xabc123...
-   export BASE_RPC_URL=https://mainnet.base.org # optional
+   export BASE_RPC_URL=https://rpc.ankr.com/base/fe0da18bd714518c9d7bb2736fc2b7432a179a7cac8d93e3f107569eee4f23e8 # optional
    npm run deploy:receipt
    ```
 

--- a/chains/default_chains.json
+++ b/chains/default_chains.json
@@ -18,7 +18,7 @@
     {
         "name": "Base",
         "chain_id": 8453,
-        "rpc_url": "https://mainnet.base.org",
+        "rpc_url": "https://rpc.ankr.com/base/fe0da18bd714518c9d7bb2736fc2b7432a179a7cac8d93e3f107569eee4f23e8",
         "currency_symbol": "ETH",
         "explorer_url": "https://basescan.org",
         "tags": ["evm", "l2"]


### PR DESCRIPTION
## Summary
- switch the default Base RPC URL to the provided Ankr endpoint
- update the deployment instructions to reference the new Base RPC URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e59c4445208325980678152acda10d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Base network RPC endpoint to an Ankr RPC URL, affecting connections made by default configurations.

* **Documentation**
  * Revised the deployment example to use the Ankr Base RPC URL instead of a placeholder mainnet URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->